### PR TITLE
Fix typos

### DIFF
--- a/lib/ex_typesense.ex
+++ b/lib/ex_typesense.ex
@@ -73,7 +73,7 @@ defmodule ExTypesense do
   defdelegate upsert_document(document), to: ExTypesense.Document
   defdelegate index_multiple_documents(documents), to: ExTypesense.Document
   defdelegate update_multiple_documents(documents), to: ExTypesense.Document
-  defdelegate upsert_multiple_documents(docuemnts), to: ExTypesense.Document
+  defdelegate upsert_multiple_documents(documents), to: ExTypesense.Document
 
   # search
   defdelegate search(collection_name, params), to: ExTypesense.Search

--- a/test/document_test.exs
+++ b/test/document_test.exs
@@ -66,7 +66,7 @@ defmodule DocumentTest do
   end
 
   test "success: adding unknown field", %{document: document} do
-    document = Map.put(document, :unknown_field, "unkown_value")
+    document = Map.put(document, :unknown_field, "unknown_value")
     {:ok, collection} = ExTypesense.create_document(document)
     assert Map.has_key?(collection, "unknown_field")
   end


### PR DESCRIPTION
Found via `codespell -S deps,doc`