### PR TITLE
Add Typesense Dashboard to local Docker Compose instances

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,10 @@
+{
+  "apiKey": "xyz",
+  "node": {
+    "host":"localhost",
+    "port":"8108",
+    "protocol":"http",
+    "path":"/",
+    "tls":false
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,18 @@ services:
     container_name: typesense
     restart: on-failure
     ports:
-      - "8108:8108"
+      - 8107:8107 # internal status
+      - 8108:8108 # typesense server
     volumes:
       - ./typesense-data:/data
     command: '--data-dir /data --api-key=xyz --enable-cors'
+  typesense_dashboard:
+    image: ghcr.io/bfritscher/typesense-dashboard:latest
+    container_name: typesense_dashboard
+    restart: on-failure
+    ports:
+      - 8109:80
+    volumes:
+      - ./config/config.json:/srv/config.json
+    depends_on:
+      - typesense

--- a/guides/running_local_typesense.md
+++ b/guides/running_local_typesense.md
@@ -63,3 +63,13 @@ docker compose logs -f
 # or specifically Typesense
 docker container logs --follow --tail 50 typesense
 ```
+
+This Docker Compose setup exposes three services with dedicated URLs:
+
+- http://localhost:8107 (Internal Server Status), provides information about the
+  health and status of your internal server.
+- http://localhost:8108 (Typesense Server and API), allows you to interact with
+  the Typesense search engine and its API functionalities.
+- http://localhost:8109 (Typesense Dashboard), opens the Typesense web interface
+  for managing your search collections and settings.
+

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -36,15 +36,15 @@ defmodule ConnectionTest do
     end
   end
 
-  test "error: health check, with incorrect API key" do
-    conn = %{api_key: "abc", host: "localhost", port: 8109, scheme: "http"}
+  test "error: health check, with incorrect port number" do
+    conn = %{api_key: "abc", host: "localhost", port: 8100, scheme: "http"}
 
     assert_raise Req.TransportError, fn ->
       ExTypesense.health(conn)
     end
   end
 
-  test "error: wrong API key was configured" do
+  test "error: wrong api key was configured" do
     conn = %{
       host: "localhost",
       api_key: "another_key",


### PR DESCRIPTION
We enable three available endpoints:
- http://localhost:8107 (internal server status)
- http://localhost:8108 (typesense server and api)
- http://localhost:8109 (typesense dashboard)

Screenshots:

![Screenshot from 2024-07-22 02-00-32](https://github.com/user-attachments/assets/38b13a3f-80a4-498c-82a4-a594ba2cd69a)

![Screenshot from 2024-07-22 02-00-39](https://github.com/user-attachments/assets/100c4385-0396-4407-8820-bee2421a3e83)
