### PR TITLE
feat(config): :white_check_mark: Add options configuration for HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ if config_env() == :prod do # if you'll use this in prod environment
     api_key: "xyz",
     host: "localhost",
     port: 8108,
-    scheme: "http"
+    scheme: "http",
+    options: %{}
   ...
 ```
+
+> **Note**: The `options` key can be used to pass additional configuration options such as custom Finch instance or receive timeout settings. You can add any options supported by Req here. For more details check [Req documentation](https://hexdocs.pm/req/Req.Steps.html#run_finch/1-request-options).
 
 > **Note**: If you use this for adding test in your app, you might want to add this in `config/test.exs`:
 
@@ -72,7 +75,8 @@ config :ex_typesense,
   api_key: "credential", # Admin API key
   host: "111222333aaabbbcc-9.x9.typesense.net" # Nodes
   port: 443,
-  scheme: "https"
+  scheme: "https",
+  options: %{}
 ```
 
 #### Option 2: Set credentials from a map

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,5 +5,6 @@ if Mix.env() in [:dev, :test] do
     api_key: "xyz",
     host: "localhost",
     port: 8108,
-    scheme: "http"
+    scheme: "http",
+    options: %{}
 end

--- a/lib/ex_typesense/http_client.ex
+++ b/lib/ex_typesense/http_client.ex
@@ -19,6 +19,10 @@ defmodule ExTypesense.HttpClient do
   @spec get_host :: String.t() | nil
   def get_host, do: Application.get_env(:ex_typesense, :host)
 
+  @doc since: "0.6.1"
+  @spec get_options :: Keyword.t()
+  def get_options, do: Application.get_env(:ex_typesense, :options, %{})
+
   @doc since: "0.1.0"
   @spec get_scheme :: String.t() | nil
   def get_scheme, do: Application.get_env(:ex_typesense, :scheme)
@@ -108,7 +112,8 @@ defmodule ExTypesense.HttpClient do
       %Req.Request{
         body: opts[:body],
         method: opts[:method] || :get,
-        url: url
+        url: url,
+        options: get_options()
       }
       |> Req.Request.put_header("x-typesense-api-key", conn.api_key)
       |> Req.Request.put_header("content-type", opts[:content_type] || "application/json")

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -1,0 +1,32 @@
+defmodule ExTypesense.HttpClientTest do
+  use ExUnit.Case, async: true
+
+  alias ExTypesense.HttpClient
+
+  setup do
+    # Backup the original configuration
+    original_config = Application.get_env(:ex_typesense, :options, %{})
+
+    on_exit(fn ->
+      # Restore the original configuration after each test
+      Application.put_env(:ex_typesense, :options, original_config)
+    end)
+  end
+
+  describe "get_options/0" do
+    test "returns the configured options" do
+      Application.put_env(:ex_typesense, :options, %{
+        finch: MyApp.CustomFinch,
+        receive_timeout: 5000
+      })
+
+      assert HttpClient.get_options() == %{finch: MyApp.CustomFinch, receive_timeout: 5000}
+    end
+
+    test "returns an empty map if options is not configured" do
+      Application.delete_env(:ex_typesense, :options)
+
+      assert HttpClient.get_options() == %{}
+    end
+  end
+end


### PR DESCRIPTION

- Added `options` configuration to `config/config.exs` for `:ex_typesense` application.
- Introduced `get_options/0` function in `ExTypesense.HttpClient` to fetch the `options` configuration.
- Updated HTTP request construction in `ExTypesense.HttpClient` to include `options`.
- Added tests for `get_options/0` in `ExTypesense.HttpClientTest`.

This change allows for additional configuration options to be passed to the HTTP client, enhancing its flexibility and configurability.