### PR TITLE
Adds a comma to configuration code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For Cloud hosted, you can generate and obtain the credentials from cluster insta
 ```elixir
 config :ex_typesense,
   api_key: "credential", # Admin API key
-  host: "111222333aaabbbcc-9.x9.typesense.net" # Nodes
+  host: "111222333aaabbbcc-9.x9.typesense.net", # Nodes
   port: 443,
   scheme: "https",
   options: %{}


### PR DESCRIPTION
Just a simple fix so that developers can copy and paste the configuration code block without problems.

Before:
![image](https://github.com/user-attachments/assets/93787acd-6204-4cd1-a701-787fecc8788f)

After:
![image](https://github.com/user-attachments/assets/0f048945-a9a3-4423-b0cd-7ee70772608c)