### PR TITLE
Support Elixir 1.19 in CI and bump actions

### DIFF
--- a/.github/workflows/ci_v26.0.yml
+++ b/.github/workflows/ci_v26.0.yml
@@ -37,6 +37,10 @@ jobs:
           otp: '27'
           elixir: '1.18'
           lint: false
+        - typesense: '26.0'
+          otp: '28'
+          elixir: '1.19'
+          lint: false
 
     services:
       typesense:
@@ -44,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for misspellings
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/ci_v27.0.yml
+++ b/.github/workflows/ci_v27.0.yml
@@ -37,6 +37,10 @@ jobs:
           otp: '27'
           elixir: '1.18'
           lint: false
+        - typesense: '27.0'
+          otp: '28'
+          elixir: '1.19'
+          lint: false
 
     services:
       typesense:
@@ -44,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for misspellings
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/ci_v27.1.yml
+++ b/.github/workflows/ci_v27.1.yml
@@ -37,6 +37,10 @@ jobs:
           otp: '27'
           elixir: '1.18'
           lint: false
+        - typesense: '27.1'
+          otp: '28'
+          elixir: '1.19'
+          lint: false
 
     services:
       typesense:
@@ -44,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for misspellings
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/ci_v28.0.yml
+++ b/.github/workflows/ci_v28.0.yml
@@ -36,6 +36,10 @@ jobs:
         - typesense: '28.0'
           otp: '27'
           elixir: '1.18'
+          lint: false
+        - typesense: '28.0'
+          otp: '28'
+          elixir: '1.19'
           lint: true
 
     services:
@@ -44,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for misspellings
         uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to test against newer Elixir/OTP combinations and bump the GitHub checkout action version.

CI:
- Add Elixir 1.19 with OTP 28 test matrix entries across Typesense 26.0, 27.0, 27.1, and 28.0 CI workflows.
- Upgrade GitHub Actions checkout step from v4 to v6 in all affected CI workflows.