### PR TITLE
Add support for v30.1

### DIFF
--- a/.github/workflows/ci_v30.1.yml
+++ b/.github/workflows/ci_v30.1.yml
@@ -1,8 +1,7 @@
-name: CI v30.0
+name: CI v30.1
 
 on:
-  pull_request:
-    branches: ["main"]
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,20 +26,20 @@ jobs:
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      LATEST_TYPESENSE: '30.0'
+      LATEST_TYPESENSE: '30.1'
 
     strategy:
       matrix:
         include:
-        - typesense: '30.0'
+        - typesense: '30.1'
           otp: '25'
           elixir: '1.14'
           lint: false
-        - typesense: '30.0'
+        - typesense: '30.1'
           otp: '27'
           elixir: '1.18'
           lint: false
-        - typesense: '30.0'
+        - typesense: '30.1'
           otp: '28'
           elixir: '1.19'
           lint: true
@@ -93,12 +92,15 @@ jobs:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
-      - name: Cache dependencies/builds
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+      - name: Restore cache
+        id: cache_restore
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        if: ${{ matrix.lint }}
         with:
           path: |
             deps
             _build
+            priv/plts
           key: ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp}}-${{ matrix.elixir}}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
@@ -132,9 +134,28 @@ jobs:
         run: mix format --check-formatted
         if: ${{ matrix.lint }}
 
+      - name: Create PLTs
+        if: ${{ steps.cache_restore.outputs.cache-hit != 'true' && matrix.lint }}
+        run: mix dialyzer --plt
+
+      - name: Dialyzer
+        run: mix dialyzer --format github --format dialyxir
+        if: ${{ matrix.lint }}
+
       - name: Run tests
         run: mix test --only ${{ matrix.typesense }}:true --only nls:true --trace
 
       - name: Post test coverage to Coveralls
         run: mix coveralls.github
         if: ${{ matrix.lint && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Save cache
+        id: cache_save
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        if: ${{ matrix.lint }}
+        with:
+          path: |
+            deps
+            _build
+            priv/plts
+          key: ${{ runner.os }}-typesense-${{ matrix.typesense }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/ci_v30.1.yml
+++ b/.github/workflows/ci_v30.1.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Post test coverage to Coveralls
         run: mix coveralls.github
-        if: ${{ matrix.lint && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ matrix.lint && github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
 
       - name: Save cache
         id: cache_save

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   ci_workflow:
-    uses: ./.github/workflows/ci_v30.0.yml
+    uses: ./.github/workflows/ci_v30.1.yml
     secrets: inherit
 
   llm:
@@ -24,6 +24,12 @@ jobs:
     strategy:
       matrix:
         include:
+        - typesense: '30.1'
+          otp: '25'
+          elixir: '1.14'
+        - typesense: '30.1'
+          otp: '28'
+          elixir: '1.18'
         - typesense: '30.0'
           otp: '25'
           elixir: '1.14'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## major.minor.patch (yyyy.mm.dd)
 
+## 2.3.0 (2026.04.14)
+
+### Chore
+
+* Update compatibility to include Typesense v30.1
+* Add tests to include v30.1
+* CI to include v30.1
+
 ## 2.2.0 (2026.04.14)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 <p align="center">
   <source
     media="(prefers-color-scheme: dark)"
-    srcset="https://raw.githubusercontent.com/typesense/typesense/refs/heads/v30/assets/typesense_logo_dark.svg">
+    srcset="https://raw.githubusercontent.com/typesense/typesense/refs/heads/v31/assets/typesense_logo_dark.svg">
   <img
     alt="Typesense logo"
-    src="https://raw.githubusercontent.com/typesense/typesense/refs/heads/v30/assets/typesense_logo.svg"
+    src="https://raw.githubusercontent.com/typesense/typesense/refs/heads/v31/assets/typesense_logo.svg"
     width="230">
   <source
     media="(prefers-color-scheme: dark)"
@@ -51,6 +51,12 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/jaeyson/ex_typesense/actions/workflows/ci_v30.1.yml">
+    <img
+      alt="CI for v30.0"
+      src="https://github.com/jaeyson/ex_typesense/actions/workflows/ci_v30.1.yml/badge.svg"
+    >
+  </a>
   <a href="https://github.com/jaeyson/ex_typesense/actions/workflows/ci_v30.0.yml">
     <img
       alt="CI for v30.0"
@@ -102,10 +108,10 @@
       src="https://img.shields.io/hexpm/l/ex_typesense"
     >
   </a>
-  <a href="https://typesense.org/docs/30.0/api">
+  <a href="https://typesense.org/docs/30.1/api">
     <img
       alt="Latest Typesense compatible version"
-      src="https://img.shields.io/badge/Latest%20Typesense%20compatible-v30.0-%230F35BC"
+      src="https://img.shields.io/badge/Latest%20Typesense%20compatible-v30.1-%230F35BC"
     >
   </a>
 </p>
@@ -147,7 +153,7 @@ Add `:ex_typesense` to your list of dependencies in the Elixir project config fi
 def deps do
   [
     # From default Hex package manager
-    {:ex_typesense, "~> 2.2"}
+    {:ex_typesense, "~> 2.3"}
 
     # Or from GitHub repository, if you want the latest greatest from main branch
     {:ex_typesense, git: "https://github.com/jaeyson/ex_typesense.git"}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 <p align="center">
   <a href="https://github.com/jaeyson/ex_typesense/actions/workflows/ci_v30.1.yml">
     <img
-      alt="CI for v30.0"
+      alt="CI for v30.1"
       src="https://github.com/jaeyson/ex_typesense/actions/workflows/ci_v30.1.yml/badge.svg"
     >
   </a>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: docker.io/typesense/typesense:30.0
+    image: docker.io/typesense/typesense:30.1
     container_name: typesense
     restart: on-failure
     ports:

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ExTypesense.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/jaeyson/ex_typesense"
-  @version "2.2.0"
+  @version "2.3.0"
 
   def project do
     [

--- a/test/analytics_test.exs
+++ b/test/analytics_test.exs
@@ -82,7 +82,7 @@ defmodule AnalyticsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): create analytics rule with non-existent collection", %{
     conn: conn,
     map_conn: map_conn
@@ -115,7 +115,7 @@ defmodule AnalyticsTest do
     assert {:error, _} = ExTypesense.create_analytics_rule(body, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): upsert analytics rule", %{conn: conn, map_conn: map_conn} do
     name = "product_no_hits"
 
@@ -143,7 +143,7 @@ defmodule AnalyticsTest do
              ExTypesense.upsert_analytics_rule(name, body, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): flush analytics", %{conn: conn, map_conn: map_conn} do
     response = {:ok, %AnalyticsEventCreateResponse{ok: true}}
 
@@ -153,7 +153,7 @@ defmodule AnalyticsTest do
     assert ^response = ExTypesense.flush_analytics(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): get analytics events", %{conn: conn, map_conn: map_conn} do
     reason = {:error, %ApiResponse{message: "Missing required parameter 'user_id'."}}
 
@@ -168,7 +168,7 @@ defmodule AnalyticsTest do
     assert ^reason = ExTypesense.get_analytics_events(opts ++ [map_conn: map_conn])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): get analytics status", %{conn: conn, map_conn: map_conn} do
     status = %AnalyticsStatus{
       doc_counter_events: 0,
@@ -186,7 +186,7 @@ defmodule AnalyticsTest do
     assert {:ok, ^status} = ExTypesense.get_analytics_status(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): send click events", %{conn: conn, map_conn: map_conn} do
     name = "products_clicks"
 
@@ -336,6 +336,7 @@ defmodule AnalyticsTest do
   end
 
   @tag [
+    "30.1": true,
     "30.1": true,
     "30.0": true,
     "29.0": true,

--- a/test/analytics_test.exs
+++ b/test/analytics_test.exs
@@ -337,7 +337,6 @@ defmodule AnalyticsTest do
 
   @tag [
     "30.1": true,
-    "30.1": true,
     "30.0": true,
     "29.0": true,
     "28.0": true,

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -21,7 +21,15 @@ defmodule ClusterTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check with empty credentials" do
     conn = %{api_key: nil, host: nil, port: nil, scheme: nil}
 
@@ -30,7 +38,15 @@ defmodule ClusterTest do
     end
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "new/1 with invalid data type raises ArgumentError" do
     invalid_inputs = [
       nil,
@@ -50,21 +66,45 @@ defmodule ClusterTest do
     end
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check, with incorrect port number" do
     conn = %{api_key: "xyz", host: "localhost", port: 8100, scheme: "http"}
 
     assert {:error, "connection refused"} = ExTypesense.health(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check, with incorrect host" do
     conn = %{api_key: "xyz", host: "my_test_host", port: 8108, scheme: "http"}
 
     assert {:error, "non-existing domain"} = ExTypesense.health(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: wrong api key was configured" do
     conn = %{
       host: "localhost",
@@ -76,7 +116,15 @@ defmodule ClusterTest do
     assert {:error, @forbidden} = ExTypesense.list_collections(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: overriding config with a wrong API key" do
     conn = %{
       host: "localhost",
@@ -88,7 +136,15 @@ defmodule ClusterTest do
     assert {:error, @forbidden} = ExTypesense.list_collections(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: Using a struct converted to map and update its keys" do
     conn = %Credential{
       node: "localhost",
@@ -107,7 +163,15 @@ defmodule ClusterTest do
     assert {:ok, %HealthStatus{ok: true}} = ExTypesense.health(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "health", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %HealthStatus{ok: true}} = ExTypesense.health()
     assert {:ok, _} = ExTypesense.health([])
@@ -115,7 +179,15 @@ defmodule ClusterTest do
     assert {:ok, _} = ExTypesense.health(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "api status", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %APIStatsResponse{}} = ExTypesense.api_stats()
     assert {:ok, _} = ExTypesense.api_stats([])
@@ -123,7 +195,15 @@ defmodule ClusterTest do
     assert {:ok, _} = ExTypesense.api_stats(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "cluster metrics", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %{}} = ExTypesense.cluster_metrics()
     assert {:ok, _} = ExTypesense.cluster_metrics([])
@@ -131,7 +211,15 @@ defmodule ClusterTest do
     assert {:ok, _} = ExTypesense.cluster_metrics(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "create snapshot", %{conn: conn, map_conn: map_conn} do
     # we have to add sleep timer for github actions
     # otherwise it will return like:
@@ -155,7 +243,15 @@ defmodule ClusterTest do
              ExTypesense.create_snapshot(snapshot_path: path, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "compact DB", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} = ExTypesense.compact_db()
     assert {:ok, _} = ExTypesense.compact_db([])
@@ -163,7 +259,15 @@ defmodule ClusterTest do
     assert {:ok, _} = ExTypesense.compact_db(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "clear cache", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} = ExTypesense.clear_cache()
     assert {:ok, _} = ExTypesense.clear_cache([])
@@ -171,7 +275,15 @@ defmodule ClusterTest do
     assert {:ok, _} = ExTypesense.clear_cache(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "toggle slow request log", %{conn: conn, map_conn: map_conn} do
     config = %{"log_slow_requests_time_ms" => :timer.seconds(2)}
     assert {:ok, %SuccessStatus{success: true}} = ExTypesense.toggle_slow_request_log(config)
@@ -180,7 +292,15 @@ defmodule ClusterTest do
     assert {:ok, _} = ExTypesense.toggle_slow_request_log(config, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "re-elect leader (vote)", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: false}} = ExTypesense.vote()
     assert {:ok, _} = ExTypesense.vote([])
@@ -188,7 +308,15 @@ defmodule ClusterTest do
     assert {:ok, _} = ExTypesense.vote(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: get schema changes", %{conn: conn, map_conn: map_conn} do
     case ExTypesense.get_schema_changes() do
       {:ok, []} ->

--- a/test/collection_test.exs
+++ b/test/collection_test.exs
@@ -45,7 +45,15 @@ defmodule CollectionTest do
     :ok
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: create collection", %{schema: schema, conn: conn, map_conn: map_conn} do
     name = schema.name
     prod_name = Product.__schema__(:source)
@@ -75,7 +83,15 @@ defmodule CollectionTest do
     assert {:ok, %CollectionResponse{name: ^prod_name}} = ExTypesense.get_collection(Product)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list all collections", %{conn: conn, map_conn: map_conn} do
     assert {:ok, _} = ExTypesense.list_collections()
     assert {:ok, _} = ExTypesense.list_collections(exclude_fields: "fields")
@@ -85,7 +101,15 @@ defmodule CollectionTest do
     assert {:ok, _} = ExTypesense.list_collections(conn: map_conn, exclude_fields: "fields")
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: clone collection", %{schema: schema, conn: conn, map_conn: map_conn} do
     name = schema.name
     prod_name = Product.__schema__(:source)
@@ -117,7 +141,15 @@ defmodule CollectionTest do
              ExTypesense.clone_collection(Product, "prod_x", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: create collection with alias", %{schema: schema, conn: conn, map_conn: map_conn} do
     assert {:ok, %CollectionResponse{name: c_collection_name}} =
              ExTypesense.create_collection_with_alias(schema)
@@ -155,7 +187,15 @@ defmodule CollectionTest do
     assert message =~ error
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: dropping collection won't affect alias", %{
     schema: schema,
     conn: conn,
@@ -216,7 +256,15 @@ defmodule CollectionTest do
     assert aliases >= 0
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: dropping unknown collection", %{conn: conn, map_conn: map_conn} do
     coll_name = "unknown"
     message = ~s(No collection with name `#{coll_name}` found.)
@@ -232,7 +280,15 @@ defmodule CollectionTest do
     assert {:error, %ApiResponse{}} = ExTypesense.drop_collection(Product, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: get unknown collection", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: message}} = ExTypesense.get_collection("xyz")
     assert String.contains?(String.downcase(message), "not found") === true
@@ -243,7 +299,15 @@ defmodule CollectionTest do
     assert {:error, _} = ExTypesense.get_collection(Product, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: dropping collection deletes all documents", %{schema: schema} do
     ExTypesense.create_collection(schema)
 
@@ -261,7 +325,15 @@ defmodule CollectionTest do
     assert String.contains?(String.downcase(message), "not found") === true
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: update schema fields", %{schema: schema, conn: conn, map_conn: map_conn} do
     assert {:ok, %CollectionResponse{}} = ExTypesense.create_collection(schema)
 
@@ -308,7 +380,15 @@ defmodule CollectionTest do
     assert test.name === "test"
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: get collection name by alias", %{schema: schema, conn: conn, map_conn: map_conn} do
     name = schema.name
 
@@ -325,7 +405,15 @@ defmodule CollectionTest do
     assert {:ok, _} = ExTypesense.get_collection_alias(alias_name, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: create, get, delete alias", %{schema: schema, conn: conn, map_conn: map_conn} do
     name = schema.name
 

--- a/test/conversation_test.exs
+++ b/test/conversation_test.exs
@@ -32,7 +32,15 @@ defmodule ConversationTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list conversation models", %{conn: conn, map_conn: map_conn} do
     case ExTypesense.list_models() do
       {:ok, []} ->
@@ -47,7 +55,15 @@ defmodule ConversationTest do
     end
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: get a non-existent conversation model", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Model not found"}} =
              ExTypesense.get_model("non-existent")
@@ -57,7 +73,15 @@ defmodule ConversationTest do
     assert {:error, _} = ExTypesense.get_model("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete a conversation model", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Model not found"}} =
              ExTypesense.delete_model("non-existent")
@@ -67,7 +91,15 @@ defmodule ConversationTest do
     assert {:error, _} = ExTypesense.delete_model("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: create a conversation model with incorrect API key", %{
     conn: conn,
     map_conn: map_conn
@@ -98,7 +130,15 @@ defmodule ConversationTest do
     assert {:error, _} = ExTypesense.create_model(body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: update a conversation model with incorrect API key", %{
     conn: conn,
     map_conn: map_conn

--- a/test/curation_sets_test.exs
+++ b/test/curation_sets_test.exs
@@ -32,7 +32,7 @@ defmodule CurationSetsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a curation set", %{conn: conn, map_conn: map_conn} do
     name = "curate_catalog"
 
@@ -68,7 +68,7 @@ defmodule CurationSetsTest do
              ExTypesense.retrieve_curation_set(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error: retrieve a non-existing curation set", %{conn: conn, map_conn: map_conn} do
     set_name = "unkown-set"
     error = {:error, %ApiResponse{message: "Curation index not found"}}
@@ -78,7 +78,7 @@ defmodule CurationSetsTest do
     assert ^error = ExTypesense.retrieve_curation_set(set_name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error: retrieve a non-existing curation set item", %{conn: conn, map_conn: map_conn} do
     name = "curate_products_error"
 
@@ -112,7 +112,7 @@ defmodule CurationSetsTest do
     assert ^error = ExTypesense.retrieve_curation_set_item(name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error: retrieving an item_id with a whitespace on its name", %{
     conn: conn,
     map_conn: map_conn
@@ -129,7 +129,7 @@ defmodule CurationSetsTest do
     assert ^error = ExTypesense.retrieve_curation_set_item(set_name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: list all curation sets", %{conn: conn, map_conn: map_conn} do
     name = "curate_products"
 
@@ -162,7 +162,7 @@ defmodule CurationSetsTest do
     assert {:ok, _} = ExTypesense.retrieve_curation_sets(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: list all curation set items", %{conn: conn, map_conn: map_conn} do
     set_name = "curate_products"
 
@@ -212,7 +212,7 @@ defmodule CurationSetsTest do
              ExTypesense.retrieve_curation_set_items(set_name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: create or update a curation set", %{conn: conn, map_conn: map_conn} do
     name = "curate_products"
 
@@ -248,7 +248,7 @@ defmodule CurationSetsTest do
              ExTypesense.upsert_curation_set(name, curation_set, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: upsert a curation set item", %{conn: conn, map_conn: map_conn} do
     set_name = "curate_products"
 
@@ -299,7 +299,7 @@ defmodule CurationSetsTest do
              ExTypesense.upsert_curation_set_item(set_name, item_id, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a curation set", %{conn: conn, map_conn: map_conn} do
     name = "curate_products_delete"
 
@@ -333,7 +333,7 @@ defmodule CurationSetsTest do
     assert ^error = ExTypesense.delete_curation_set(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a curation set item", %{conn: conn, map_conn: map_conn} do
     name = "curate_products_item"
 

--- a/test/curation_test.exs
+++ b/test/curation_test.exs
@@ -34,7 +34,7 @@ defmodule CurationTest do
     %{schema_name: name, schema: schema, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for upsert search override", %{
     schema_name: schema_name
   } do
@@ -62,7 +62,7 @@ defmodule CurationTest do
     assert ^error = ExTypesense.upsert_override(House, override_id, body, [])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for get search override", %{
     schema: schema
   } do
@@ -74,7 +74,7 @@ defmodule CurationTest do
     assert ^error = ExTypesense.get_override(House, name, [])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for list collection overrides", %{
     schema_name: schema_name
   } do
@@ -85,7 +85,7 @@ defmodule CurationTest do
     assert ^error = ExTypesense.list_overrides(House, [])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for delete search override", %{
     schema_name: schema_name
   } do

--- a/test/debug_test.exs
+++ b/test/debug_test.exs
@@ -10,7 +10,15 @@ defmodule DebugTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "debug (v29.0)", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %{"state" => 1, "version" => _version}} = ExTypesense.debug()
     assert {:ok, _} = ExTypesense.debug([])

--- a/test/document_test.exs
+++ b/test/document_test.exs
@@ -66,7 +66,15 @@ defmodule DocumentTest do
     :ok
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: get unknown document", %{schema: schema, conn: conn, map_conn: map_conn} do
     unknown_id = "999"
     message = ~s(Could not find a document with id: #{unknown_id})
@@ -96,7 +104,15 @@ defmodule DocumentTest do
              ExTypesense.get_document(schema.name, unknown_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: index a document using a map then fetch if indexed", %{
     document: document,
     conn: conn,
@@ -126,7 +142,15 @@ defmodule DocumentTest do
     assert {:ok, %{company_name: ^company_name}} = ExTypesense.get_document(coll_name, id)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: adding unknown field", %{document: document} do
     document = Map.put(document, :unknown_field, "unknown_value")
 
@@ -135,7 +159,15 @@ defmodule DocumentTest do
     assert {:ok, %{id: ^id}} = ExTypesense.get_document(document.collection_name, id)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: collection_name field removed in return value when indexing or updating", %{
     document: document
   } do
@@ -156,7 +188,15 @@ defmodule DocumentTest do
     refute Map.has_key?(updated_map, :collection_name)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: upsert to update a document", %{document: document} do
     assert {:ok, %{id: id}} = ExTypesense.index_document(document)
     company_name = "Stark Industries"
@@ -170,7 +210,15 @@ defmodule DocumentTest do
              ExTypesense.index_document(updated_document, action: "upsert")
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: creates a document with a specific id twice", %{document: document} do
     document = Map.put(document, :id, "99")
     assert {:ok, %{id: id}} = ExTypesense.index_document(document)
@@ -178,7 +226,15 @@ defmodule DocumentTest do
     assert {:error, %ApiResponse{message: ^message}} = ExTypesense.index_document(document)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: update a document", %{document: document, conn: conn, map_conn: map_conn} do
     assert {:ok, %{id: id}} = ExTypesense.index_document(document)
 
@@ -219,7 +275,15 @@ defmodule DocumentTest do
     assert {:ok, _} = ExTypesense.update_document(updated_struct, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: export documents", %{
     schema: schema,
     multiple_documents: multiple_documents,
@@ -245,7 +309,15 @@ defmodule DocumentTest do
     assert {:ok, _} = ExTypesense.export_documents(Person, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete a document", %{
     schema: schema,
     document: document,
@@ -315,7 +387,15 @@ defmodule DocumentTest do
     assert {:ok, _} = ExTypesense.delete_document(person, ignore_not_found: true)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: deletes a document by struct", %{conn: conn, map_conn: map_conn} do
     person = %Person{name: "John Smith", persons_id: 99, country: "Brazil"}
 
@@ -349,7 +429,15 @@ defmodule DocumentTest do
     assert {:ok, _} = ExTypesense.delete_document(person, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: index multiple documents", %{
     schema: schema,
     multiple_documents: multiple_documents,
@@ -386,7 +474,15 @@ defmodule DocumentTest do
              ExTypesense.import_documents(Person, persons, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: update multiple documents", %{
     multiple_documents: multiple_documents,
     schema: schema
@@ -414,7 +510,15 @@ defmodule DocumentTest do
              ExTypesense.get_document(schema.name, second_id)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete all documents using Ecto schema module", %{conn: conn, map_conn: map_conn} do
     person = %Person{name: "John Doe", persons_id: 1_111, country: "Scotland"}
 
@@ -432,7 +536,15 @@ defmodule DocumentTest do
     assert {:ok, _} = ExTypesense.delete_all_documents(Person, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: deleting all documents won't drop the collection", %{
     schema: schema,
     conn: conn,
@@ -474,7 +586,15 @@ defmodule DocumentTest do
     assert {:ok, %CollectionResponse{name: ^name}} = ExTypesense.get_collection(name)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: update documents by query no change", %{
     schema: schema,
     multiple_documents: multiple_documents,
@@ -521,7 +641,15 @@ defmodule DocumentTest do
     assert {:ok, _} = ExTypesense.update_documents_by_query(Person, body, opts)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete documents by query (Ecto schema)", %{conn: conn, map_conn: map_conn} do
     john_toe = %Person{name: "John Toe", persons_id: 32, country: "Egypt"}
     john_foe = %Person{name: "John Foe", persons_id: 14, country: "Cuba"}
@@ -560,7 +688,15 @@ defmodule DocumentTest do
     end
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete documents by query (map)", %{schema: schema} do
     documents = [
       %{

--- a/test/key_test.exs
+++ b/test/key_test.exs
@@ -28,7 +28,15 @@ defmodule KeyTest do
     %{api_key_schema: api_key_schema, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: get keys", %{api_key_schema: api_key_schema, conn: conn, map_conn: map_conn} do
     assert {:ok, api_key} = ExTypesense.create_key(api_key_schema)
     assert {:ok, _} = ExTypesense.create_key(api_key_schema, [])
@@ -43,7 +51,15 @@ defmodule KeyTest do
     assert {:ok, %ApiKey{id: ^key_id}} = ExTypesense.get_key(key_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete keys", %{api_key_schema: api_key_schema, conn: conn, map_conn: map_conn} do
     assert {:ok, api_key} = ExTypesense.create_key(api_key_schema)
     key_id = api_key.id
@@ -54,7 +70,15 @@ defmodule KeyTest do
     assert {:error, _} = ExTypesense.delete_key(key_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list all keys", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %ApiKeysResponse{}} = ExTypesense.list_keys()
     assert {:ok, _} = ExTypesense.list_keys([])

--- a/test/preset_test.exs
+++ b/test/preset_test.exs
@@ -24,7 +24,15 @@ defmodule PresetTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: retrieve presets", %{conn: conn, map_conn: map_conn} do
     body =
       %{
@@ -48,7 +56,15 @@ defmodule PresetTest do
     assert {:ok, _} = ExTypesense.get_preset(name, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete presets", %{conn: conn, map_conn: map_conn} do
     body =
       %{
@@ -69,7 +85,15 @@ defmodule PresetTest do
     assert {:error, _} = ExTypesense.delete_preset(name, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list all search presets", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %PresetsRetrieveSchema{presets: _}} = ExTypesense.list_presets()
     assert {:ok, _} = ExTypesense.list_presets([])

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -54,7 +54,15 @@ defmodule SearchTest do
     %{catalog: catalog, coll_name: name, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: search a document", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     shoes =
       [
@@ -125,13 +133,29 @@ defmodule SearchTest do
     assert {:ok, %SearchResult{found: 2}} = ExTypesense.search(Truck, trucks_opts)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: search with empty result", %{coll_name: coll_name} do
     opts = [q: "test", query_by: "shoe_type"]
     assert {:ok, %SearchResult{found: 0}} = ExTypesense.search(coll_name, opts)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: search with Ecto", %{catalog: catalog, conn: conn, map_conn: map_conn} do
     catalog_coll_name = Catalog.__schema__(:source)
 
@@ -149,7 +173,15 @@ defmodule SearchTest do
     assert %Ecto.Query{} = ExTypesense.search_ecto(Catalog, opts)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: empty results from multi_search Ecto" do
     searches = [
       %{collection: Catalog, q: "non-existent-duck", query_by: "name"},
@@ -159,7 +191,15 @@ defmodule SearchTest do
     assert [] = ExTypesense.multi_search_ecto(searches)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: multi_search Ecto", %{conn: conn, map_conn: map_conn} do
     catalogs_id = 4_441
 
@@ -182,7 +222,15 @@ defmodule SearchTest do
     assert [%Ecto.Query{} | _] = ExTypesense.multi_search_ecto(searches, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: search with 1 Ecto query result" do
     catalog = %Catalog{
       name: "Rubber Ducks in Bulk",
@@ -202,7 +250,15 @@ defmodule SearchTest do
              ExTypesense.search_ecto(Catalog, opts)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: multi_search string or module collection name" do
     catalog = %Catalog{
       name: "60 Pcs Mini Resin Ducks",
@@ -221,7 +277,15 @@ defmodule SearchTest do
              ExTypesense.multi_search(searches)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: multi_search (vector) with result", %{coll_name: coll_name} do
     shoes =
       [
@@ -276,7 +340,15 @@ defmodule SearchTest do
     assert [%{document: %{shoe_type: "athletic"}} | _rest] = hits
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: multi-search with no documents", %{conn: conn, map_conn: map_conn} do
     searches = [
       %{"collection" => "shoes", "q" => "Nike", "query_by" => "description"},
@@ -296,7 +368,15 @@ defmodule SearchTest do
     assert {:ok, _} = ExTypesense.multi_search(searches, opts)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: multi_search with vector_search by an id that doesn't exist", %{
     coll_name: coll_name
   } do
@@ -316,7 +396,15 @@ defmodule SearchTest do
              ExTypesense.multi_search(searches)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: search with non-existent collection" do
     opts = [q: "duck", query_by: "name"]
 
@@ -380,7 +468,15 @@ defmodule SearchTest do
              ExTypesense.multi_search_ecto(searches)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: union multi_search", %{conn: conn, map_conn: map_conn, coll_name: coll_name} do
     shoes =
       [

--- a/test/stemming_test.exs
+++ b/test/stemming_test.exs
@@ -30,7 +30,15 @@ defmodule StemmingTest do
     %{id: id, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: create stemming dictionaries", %{conn: conn, map_conn: map_conn} do
     id = "example-stemming"
 
@@ -62,7 +70,15 @@ defmodule StemmingTest do
             ]} = ExTypesense.import_stemming_dictionary(body, id: id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: list stemming dictionaries", %{conn: conn, map_conn: map_conn} do
     case ExTypesense.list_stemming_dictionaries() do
       {:ok, map} when is_map(map) ->
@@ -77,7 +93,15 @@ defmodule StemmingTest do
     assert {:ok, _} = ExTypesense.list_stemming_dictionaries(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "error: non-existent stemming dictionary" do
     assert {:error, %ApiResponse{message: message}} =
              ExTypesense.get_stemming_dictionary("non-existent")
@@ -85,7 +109,15 @@ defmodule StemmingTest do
     assert String.contains?(String.downcase(message), "not found") === true
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: get specific stemming dictionary", %{id: id, conn: conn, map_conn: map_conn} do
     body = [
       %{"word" => "mice", "root" => "mouse"},

--- a/test/stopwords_test.exs
+++ b/test/stopwords_test.exs
@@ -24,7 +24,7 @@ defmodule StopwordsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true]
+  @tag ["30.1": true, "30.0": true, "29.0": true]
   test "success (v29.0): get stopword", %{conn: conn, map_conn: map_conn} do
     stop_id = "stopword_set_countries"
 
@@ -48,7 +48,15 @@ defmodule StopwordsTest do
     assert {:ok, _} = ExTypesense.get_stopword(stop_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: get stopword", %{conn: conn, map_conn: map_conn} do
     stop_id = "stopword_set_countries"
 
@@ -77,7 +85,15 @@ defmodule StopwordsTest do
     assert {:ok, _} = ExTypesense.get_stopword(stop_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list all stopwords", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %StopwordsSetsRetrieveAllSchema{}} = ExTypesense.list_stopwords()
     assert {:ok, _} = ExTypesense.list_stopwords([])
@@ -85,7 +101,15 @@ defmodule StopwordsTest do
     assert {:ok, _} = ExTypesense.list_stopwords(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete stopword", %{conn: conn, map_conn: map_conn} do
     stop_id = "stopword_set_countries"
 

--- a/test/synonym_test.exs
+++ b/test/synonym_test.exs
@@ -128,7 +128,7 @@ defmodule SynonymTest do
     assert {:error, %ApiResponse{}} = ExTypesense.delete_synonym(Car, syn_id, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for list collection synonyms", %{coll_name: coll_name} do
     error = {:error, %ApiResponse{message: "Not Found"}}
     assert ^error = ExTypesense.list_synonyms(coll_name)
@@ -137,7 +137,7 @@ defmodule SynonymTest do
     assert ^error = ExTypesense.list_synonyms(Car, [])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for upsert a collection synonym", %{
     coll_name: coll_name
   } do
@@ -154,7 +154,7 @@ defmodule SynonymTest do
     assert ^error = ExTypesense.upsert_synonym(Car, synonym_id, body)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for delete a collection synonym", %{
     coll_name: coll_name
   } do
@@ -171,7 +171,7 @@ defmodule SynonymTest do
     assert ^error = ExTypesense.upsert_synonym(coll_name, synonym_id, body, [])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a synonym set item", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -206,7 +206,7 @@ defmodule SynonymTest do
     assert ^error = ExTypesense.delete_synonym_set_item(name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecate function delete a synonym associated with a collection", %{
     coll_name: coll_name
   } do
@@ -218,7 +218,7 @@ defmodule SynonymTest do
     assert ^error = ExTypesense.delete_synonym(Car, synonym_id, [])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: list all synonym sets", %{conn: conn, map_conn: map_conn} do
     name = "sample"
 
@@ -240,7 +240,7 @@ defmodule SynonymTest do
     assert {:ok, _} = ExTypesense.retrieve_synonym_sets(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a synonym set", %{conn: conn, map_conn: map_conn} do
     name = "sample"
 
@@ -264,7 +264,7 @@ defmodule SynonymTest do
              ExTypesense.retrieve_synonym_set(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a synonym set item", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -303,7 +303,7 @@ defmodule SynonymTest do
              ExTypesense.retrieve_synonym_set_item(name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a synonym set items", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -336,7 +336,7 @@ defmodule SynonymTest do
     assert {:ok, _} = ExTypesense.retrieve_synonym_set_items(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for get a collection synonym", %{coll_name: coll_name} do
     synonym_id = "t-shirt-synonyms"
     error = {:error, %ApiResponse{message: "Not Found"}}
@@ -346,7 +346,7 @@ defmodule SynonymTest do
     assert ^error = ExTypesense.get_synonym(Car, synonym_id, [])
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: create or update a synonym set (multi-way synonym)", %{
     conn: conn,
     map_conn: map_conn
@@ -372,7 +372,7 @@ defmodule SynonymTest do
              ExTypesense.upsert_synonym_set(name, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: create or update a synonym set (one-way synonym)", %{
     conn: conn,
     map_conn: map_conn
@@ -399,7 +399,7 @@ defmodule SynonymTest do
              ExTypesense.upsert_synonym_set(name, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: upsert a synonym set item", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -435,7 +435,7 @@ defmodule SynonymTest do
              ExTypesense.upsert_synonym_set_item(name, item_id, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a synonym set", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 


### PR DESCRIPTION
Closes #92

## Summary by Sourcery

Add official support and CI coverage for Typesense v30.1 while bumping the library release and documentation to this version.

Enhancements:
- Expand version tags across existing test suites to run against Typesense v30.1 alongside previously supported server versions.
- Introduce a dedicated CI workflow for Typesense v30.1 and wire it into the LLM workflow matrix.
- Simplify the v30.0 CI workflow caching strategy by using a single cache step and removing Dialyzer-related caching and execution.

Build:
- Add a new GitHub Actions workflow for running the test matrix against Typesense v30.1.
- Update the LLM GitHub Actions workflow to consume the v30.1 CI workflow and extend its test matrix with v30.1 jobs.
- Adjust the existing v30.0 CI workflow trigger and caching configuration.

Documentation:
- Update README badges, assets, compatibility link, and installation snippet to reference Typesense v30.1 and ex_typesense v2.3.0.

Chores:
- Bump project version to 2.3.0 and update the default Typesense Docker image to 30.1 in docker-compose.